### PR TITLE
ci(l10n): ignore vendor directory for translations

### DIFF
--- a/.l10nignore
+++ b/.l10nignore
@@ -1,2 +1,3 @@
 # compiled vue templates
 js/
+vendor/


### PR DESCRIPTION
Small prep before enabling translations for the app: https://github.com/nextcloud/docker-ci/issues/695