### PR TITLE
chore(deps): update bootstrap.php from template

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,17 +1,9 @@
 <?php
 
-/**
- * Nextcloud - integration_docusign
- *
- * This file is licensed under the Affero General Public License version 3 or
- * later. See the COPYING file.
- *
- * @author Florian Klinger <florian.klinger@nextcloud.com>
- * @copyright Florian Klinger 2023
- */
+declare(strict_types=1);
 
-require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/bootstrap.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-\OC_App::loadApp(\OCA\DocuSign\AppInfo\Application::APP_ID);
+\OC_App::loadApp(OCA\DocuSign\AppInfo\Application::APP_ID);
+OC_Hook::clear();


### PR DESCRIPTION
Fixes PHPUnit 8.4 tests as `OC::$loader` is removed in Nextcloud 32.