### PR TITLE
chore: prepare 4.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.2.0] - 2026-07-15
+
+### Changed
+
+* Bumped max-version to Nextcloud 35
+* Multiple dependency updates
+
 ## [4.1.0] - 2026-03-19
 
 ### Changed
@@ -107,7 +114,8 @@ Major version update due to Nextcloud 28 incompatibility from previous release.
 
 * Ability to request signature via DocuSign for all PDF files
 
-[Unreleased]: https://github.com/nextcloud/integration_docusign/compare/v4.1.0...HEAD
+[Unreleased]: https://github.com/nextcloud/integration_docusign/compare/v4.2.0...HEAD
+[4.2.0]: https://github.com/nextcloud/integration_docusign/compare/v4.1.0...v4.2.0
 [4.1.0]: https://github.com/nextcloud/integration_docusign/compare/v4.0.0...v4.1.0
 [4.0.0]: https://github.com/nextcloud/integration_docusign/compare/v3.0.0...v4.0.0
 [3.0.0]: https://github.com/nextcloud/integration_docusign/compare/v2.0.6...v3.0.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@
 	<screenshot>https://raw.githubusercontent.com/nc-fkl/integration_docusign/main/img/screenshot_docusign_2.png</screenshot>
 	<screenshot>https://raw.githubusercontent.com/nc-fkl/integration_docusign/main/img/screenshot_docusign_3.png</screenshot>
 	<dependencies>
-		<nextcloud min-version="33" max-version="34"/>
+		<nextcloud min-version="33" max-version="35"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\DocuSign\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>DocuSign integration</name>
 	<summary>Let users sign files via DocuSign</summary>
 	<description><![CDATA[Sign files via DocuSign Service.]]></description>
-	<version>4.1.0</version>
+	<version>4.2.0</version>
 	<licence>AGPL-3.0-or-later</licence>
 	<author mail="contact@edward.ly" homepage="https://edward.ly/">Edward Ly</author>
 	<author>Florian Klinger</author>


### PR DESCRIPTION
### Changed

* Bumped max-version to Nextcloud 35
* Multiple dependency updates